### PR TITLE
init blockfrost-freer-client

### DIFF
--- a/blockfrost-freer-client/CHANGELOG.md
+++ b/blockfrost-freer-client/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Version [0.1.0.0](https://github.com/blockfrost/blockfrost-haskell/compare/0.1.0.0...0.1.1.0) (2021-08-24)
+
+* Initial release
+
+---
+
+`blockfrost-freer-client` uses [PVP Versioning][1].
+
+[1]: https://pvp.haskell.org
+

--- a/blockfrost-freer-client/LICENSE
+++ b/blockfrost-freer-client/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2022 blockfrost.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/blockfrost-freer-client/README.md
+++ b/blockfrost-freer-client/README.md
@@ -1,0 +1,3 @@
+# blockfrost-freer-client
+
+Freer Client!

--- a/blockfrost-freer-client/Setup.hs
+++ b/blockfrost-freer-client/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/blockfrost-freer-client/blockfrost-freer-client.cabal
+++ b/blockfrost-freer-client/blockfrost-freer-client.cabal
@@ -1,0 +1,90 @@
+cabal-version:       2.2
+name:                blockfrost-freer-client
+version:             0.1.0.0
+synopsis:            blockfrost.io freer-simple client
+description:         Blockfrost client for use with freer-simple
+homepage:            https://github.com/blockfrost/blockfrost-haskell
+license:             Apache-2.0
+license-file:        LICENSE
+author:              blockfrost.io
+maintainer:          srk@48.io
+copyright:           2021 blockfrost.io
+category:            Web
+build-type:          Simple
+
+
+extra-source-files:
+    CHANGELOG.md
+    LICENSE
+    README.md
+
+flag BuildFast
+     Default: True
+     Description: Turn off optimizations
+
+flag Examples
+     Default: False
+     Description: Build examples
+
+flag Production
+     Default: False
+     Description: Production build
+
+common libstuff
+  default-language:    Haskell2010
+  default-extensions:
+    DataKinds
+    DeriveAnyClass
+    DeriveGeneric
+    DerivingVia
+    GADTs
+    GeneralizedNewtypeDeriving
+    FlexibleContexts
+    FlexibleInstances
+    InstanceSigs
+    LambdaCase
+    MultiParamTypeClasses
+    RankNTypes
+    ScopedTypeVariables
+    TemplateHaskell
+    TypeApplications
+    TypeFamilies
+    TypeOperators
+    ViewPatterns
+    OverloadedStrings
+  ghc-options:         -Wall -Wunused-packages
+                       -fno-specialize
+                       -- ^ this helps quite a lot
+                       -- with memory usage
+                       -- https://github.com/haskell-servant/servant/issues/986
+                       -- but -O0 is even better
+  if flag(BuildFast)
+    ghc-options: -O0
+  if flag(Production)
+    ghc-options: -Werror
+
+library
+   import:              libstuff
+   hs-source-dirs:      src
+   exposed-modules:     Blockfrost.Freer.Client
+   build-depends:       base >= 4.7 && < 5
+                      , blockfrost-api
+                      , blockfrost-client
+                      , blockfrost-client-core
+                      , freer-simple
+                      , servant-client        ^>= 0.18
+
+executable blockfrost-freer-client-example
+  if !flag(Examples)
+    buildable: False
+  hs-source-dirs:      example
+  main-is:             Main.hs
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , blockfrost-freer-client
+                     , freer-simple
+  default-language:    Haskell2010
+
+source-repository head
+  type:     git
+  location: https://github.com/blockfrost/blockfrost-haskell

--- a/blockfrost-freer-client/example/Main.hs
+++ b/blockfrost-freer-client/example/Main.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Main
+  where
+
+import Blockfrost.Freer.Client
+import Control.Monad.Freer
+import Control.Monad.Freer.Error
+import Control.Monad.Freer.Reader
+import Control.Monad.Freer.State
+
+-- | Example similar to blockfrost-client main, except using catchError
+simpleMain = do
+  -- reads token from BLOCKFROST_TOKEN_PATH
+  -- environment variable. It expects token
+  -- prefixed with Blockfrost environment name
+  -- e.g.: testnet-someTokenHash
+  prj <- projectFromEnv
+  res <- runBlockfrost prj $ do
+    latestBlocks <- getLatestBlock
+    (ers :: Either BlockfrostError [AccountReward]) <-
+      catchError (Right <$> getAccountRewards "gonnaFail")
+        (\e -> pure $ Left e)
+
+    -- variant accepting @Paged@ and @SortOrder@ arguments
+    -- getAccountRewards' "gonnaFail" (page 10) desc
+    pure (latestBlocks, ers)
+  print res
+
+-- | Example of using custom effect stack
+main = do
+  -- reads token from BLOCKFROST_TOKEN_PATH
+  -- environment variable. It expects token
+  -- prefixed with Blockfrost environment name
+  -- e.g.: testnet-someTokenHash
+  handleBlockfrostClient <- defaultBlockfrostHandler
+  res <-
+    runM
+      . runState @(Maybe Block) Nothing
+      . runReader @Int 42
+      . handleBlockfrostClient
+      $ do
+          latestBlock <- getLatestBlock
+          put (Just latestBlock)
+          z <- ask @Int
+          (ers :: Either BlockfrostError [AccountReward]) <-
+            catchError (Right <$> getAccountRewards "gonnaFail")
+              (\e -> pure $ Left e)
+
+          pure (latestBlock, ers)
+  print res

--- a/blockfrost-freer-client/src/Blockfrost/Freer/Client.hs
+++ b/blockfrost-freer-client/src/Blockfrost/Freer/Client.hs
@@ -1,0 +1,89 @@
+-- | Blockfrost freer client
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Blockfrost.Freer.Client (
+    module Blockfrost.Client
+
+  -- Eff
+  , ClientEffects
+  , defaultBlockfrostHandler
+  , handleBlockfrostClientEffects
+  , runBlockfrost
+  , tryError
+  )
+  where
+
+import Blockfrost.Client hiding (runBlockfrost, tryError)
+
+import Control.Monad.IO.Class
+import Control.Monad.Freer
+import Control.Monad.Freer.Reader
+import Control.Monad.Freer.Error
+
+import Servant.Client
+
+instance
+  ( MonadIO m
+  , LastMember m effs
+  , Member (Reader ClientConfig) effs
+  , Member (Error BlockfrostError) effs
+  )
+  => MonadBlockfrost (Eff effs) where
+
+  liftBlockfrostClient act = getConf >>= \(env, _prj) ->
+    (liftIO $ runClientM act env) >>= either (throwError . fromServantClientError) pure
+
+  getConf = ask
+
+type ClientEffects' effs =
+    Reader ClientConfig
+ ': Error BlockfrostError
+ ': effs
+
+type ClientEffects = ClientEffects' '[]
+
+handleBlockfrostClientEffects ::
+  forall m effs a .
+  ( LastMember m effs
+  , MonadIO m
+  )
+  => ClientConfig
+  -> Eff (ClientEffects' effs) a
+  -> Eff effs (Either BlockfrostError a)
+handleBlockfrostClientEffects cfg act = do
+      runError @BlockfrostError
+    . runReader @ClientConfig cfg
+    $ act
+
+defaultBlockfrostHandler
+  :: forall effs a
+  . (LastMember IO effs)
+  => IO (Eff (ClientEffects' effs) a -> Eff effs (Either BlockfrostError a))
+defaultBlockfrostHandler = do
+  cfg <- newClientConfig
+  pure $ handleBlockfrostClientEffects cfg
+
+runBlockfrost
+  :: Project
+  -> Eff (ClientEffects' '[IO]) a
+  -> IO (Either BlockfrostError a)
+runBlockfrost prj act = do
+  env <- newEnvByProject prj
+  runM . handleBlockfrostClientEffects (env, prj) $ act
+
+-- Catch error effect @Error@ and return
+-- either result or error type.
+tryError
+  :: Member (Error e) effs
+  => Eff effs a
+  -> Eff effs (Either e a)
+tryError act = (Right <$> act) `catchError` (pure . Left)
+
+_example :: IO ()
+_example = do
+  bfHandler <- defaultBlockfrostHandler
+  x <- runM
+    . bfHandler
+    $ getLatestBlock
+  print x


### PR DESCRIPTION
Closes #3.

Turns out we only need a small stub library thanks to https://github.com/blockfrost/blockfrost-haskell/pull/11