### PR TITLE
Improve error handling

### DIFF
--- a/chain-watcher/src/ChainWatcher.hs
+++ b/chain-watcher/src/ChainWatcher.hs
@@ -283,7 +283,8 @@ watch = do
                 _ -> pure ()
 
         case res of
-          Left e -> rethrow e
+          Left e -> do
+            logs $ "Error caught during new block processing loop " <> (showText e)
           Right handled -> do
             put @Block $ Prelude.last newBlocks
             modify @[Block] $ \xs -> take maxRollbackSize $ reverse newBlocks ++ xs


### PR DESCRIPTION
- `async` swallows exceptions so use `forkIO` for now
- Some API errors can happen during new block processing caused by rollback which is expected and we just log the exception and keep the chain pointer (last processed block(s)) intact for the next iteration to retry. 